### PR TITLE
Fix parsing of duration in when reading meta data

### DIFF
--- a/src/main/java/it/sauronsoftware/jave/Encoder.java
+++ b/src/main/java/it/sauronsoftware/jave/Encoder.java
@@ -551,8 +551,6 @@ public class Encoder {
 								+ (hours * 60L * 60L * 1000L);
 						info.setDuration(duration);
 						step++;
-					} else {
-						step = 3;
 					}
 				} else if (step == 2) {
 					Matcher m = p3.matcher(line);


### PR DESCRIPTION
When I use 

        Encoder encoder = new Encoder();
        try {
            MultimediaInfo info = encoder.getInfo(musicFile);
            System.out.println(info.getDuration());
        } catch (EncoderException e) {
            e.printStackTrace();
        }

I always get -1 duration for .mp3 and .flac files (ffmpeg 4.0.3 on Linux 64bit). This is because my ffmpeg gives output shown at the end. Jave expects line after "Input #" to be "Duration", but its "Metadata". With above fix it works. Unsure why original code stops parsing when 'Duration" is not found in line right after "Input".

> ffmpeg version 4.0.3 Copyright (c) 2000-2018 the FFmpeg developers
  built with gcc 8 (GCC)
  configuration: --prefix=/usr --bindir=/usr/bin --datadir=/usr/share/ffmpeg --docdir=/usr/share/doc/ffmpeg --incdir=/usr/include/ffmpeg --libdir=/usr/lib64 --mandir=/usr/share/man --arch=x86_64 --optflags='-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection' --extra-ldflags='-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld ' --extra-cflags=' ' --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-version3 --enable-bzlib --disable-crystalhd --enable-fontconfig --enable-frei0r --enable-gcrypt --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libcdio --enable-libdrm --enable-indev=jack --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libmp3lame --enable-nvenc --enable-openal --enable-opencl --enable-opengl --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-librsvg --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libvorbis --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvpx --enable-libx264 --enable-libx265 --enable-libxvid --enable-libzvbi --enable-avfilter --enable-avresample --enable-postproc --enable-pthreads --disable-static --enable-shared --enable-gpl --disable-debug --disable-stripping --shlibdir=/usr/lib64 --enable-libmfx --enable-runtime-cpudetect
  libavutil      56. 14.100 / 56. 14.100
  libavcodec     58. 18.100 / 58. 18.100
  libavformat    58. 12.100 / 58. 12.100
  libavdevice    58.  3.100 / 58.  3.100
  libavfilter     7. 16.100 /  7. 16.100
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  1.100 /  5.  1.100
  libswresample   3.  1.100 /  3.  1.100
  libpostproc    55.  1.100 / 55.  1.100
Input #0, mp3, from '/home/xyz/music/The Orange Box/01 - Still Alive.mp3':
  Metadata:
    title           : Still Alive
    artist          : Jonathan Coulton & GLaDOS
    album_artist    : Various Artists
    album           : The Orange Box
    disc            : 01
    track           : 01
    date            : 2007
  Duration: 00:02:56.48, start: 0.025056, bitrate: 244 kb/s
    Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 234 kb/s
    Metadata:
      encoder         : LAME3.97 
    Side data:
      replaygain: track gain - -9.500000, track peak - unknown, album gain - unknown, album peak - unknown, 
    Stream #0:1: Video: mjpeg, yuvj444p(pc, bt470bg/unknown/unknown), 500x714 [SAR 166:166 DAR 250:357], 90k tbr, 90k tbn, 90k tbc
    Metadata:
      title           : The Orange Box (Original Soundtrack).jpg
      comment         : Other
At least one output file must be specified