### PR TITLE
VideoUtils 新增m3u8方法

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,33 +4,33 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.dadiyang</groupId>
+    <groupId>com.github.zywayh</groupId>
     <artifactId>jave</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>9</version>
     </parent>
-    <licenses>
-        <license>
-            <name>GNU General Public License (GPL)</name>
-            <url>http://www.gnu.org/licenses/gpl.txt</url>
-        </license>
-    </licenses>
-    <scm>
-        <url>https://github.com/dadiyang/jave</url>
-        <connection>https://github.com/dadiyang/jave.git</connection>
-        <developerConnection>https://github.com/dadiyang/jave</developerConnection>
-    </scm>
-    <developers>
-        <developer>
-            <name>Xuyang Huang</name>
-            <email>dadiyang@aliyun.com</email>
-            <url>https://github.com/dadiyang/jave</url>
-        </developer>
-    </developers>
+    <!--<licenses>-->
+        <!--<license>-->
+            <!--<name>GNU General Public License (GPL)</name>-->
+            <!--<url>http://www.gnu.org/licenses/gpl.txt</url>-->
+        <!--</license>-->
+    <!--</licenses>-->
+    <!--<scm>-->
+        <!--<url>https://github.com/dadiyang/jave</url>-->
+        <!--<connection>https://github.com/dadiyang/jave.git</connection>-->
+        <!--<developerConnection>https://github.com/dadiyang/jave</developerConnection>-->
+    <!--</scm>-->
+    <!--<developers>-->
+        <!--<developer>-->
+            <!--<name>Xuyang Huang</name>-->
+            <!--<email>dadiyang@aliyun.com</email>-->
+            <!--<url>https://github.com/dadiyang/jave</url>-->
+        <!--</developer>-->
+    <!--</developers>-->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.25</slf4j.version>
@@ -54,7 +54,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
+        <finalName>jave</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -72,5 +74,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <!-- nexus私服配置 start -->
+    <distributionManagement>
+        <repository>
+            <id>releases</id>
+            <url>http://47.95.13.52:16500/repository/maven-releases/</url>
+        </repository>
+    </distributionManagement>
+    <!-- nexus私服配置 start -->
+
 
 </project>

--- a/src/main/java/it/sauronsoftware/jave/AudioUtils.java
+++ b/src/main/java/it/sauronsoftware/jave/AudioUtils.java
@@ -45,9 +45,6 @@ public class AudioUtils {
     }
 
     public static void convert(File source, File target, String format) {
-        if (!source.exists()) {
-            throw new IllegalArgumentException("source file does not exists: " + source.getAbsoluteFile());
-        }
         AudioAttributes audio = new AudioAttributes();
         Encoder encoder = new IgnoreErrorEncoder();
         audio.setCodec(LIBMP_3_LAME);

--- a/src/main/java/it/sauronsoftware/jave/DefaultFFMPEGLocator.java
+++ b/src/main/java/it/sauronsoftware/jave/DefaultFFMPEGLocator.java
@@ -109,7 +109,7 @@ public class DefaultFFMPEGLocator extends FFMPEGLocator {
     }
 
     @Override
-    protected String getFFMPEGExecutablePath() {
+    public String getFFMPEGExecutablePath() {
         return path;
     }
 

--- a/src/main/java/it/sauronsoftware/jave/Encoder.java
+++ b/src/main/java/it/sauronsoftware/jave/Encoder.java
@@ -22,10 +22,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.StringTokenizer;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -846,7 +845,6 @@ public class Encoder {
 	}
 
 	protected void processErrorOutput(EncodingAttributes attributes, BufferedReader errorReader, File source, EncoderProgressListener listener) throws EncoderException, IOException {
-		String lastWarning = null;
 		long progress = 0L;
 		Float offsetAttribute = attributes.getOffset();
 		MultimediaInfo info = parseMultimediaInfo(source, (RBufferedReader)errorReader);
@@ -867,76 +865,53 @@ public class Encoder {
 		}
 		int step = 0;
 		String line;
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("HH:mm:ss");
+		Calendar calendar = Calendar.getInstance();
 		while ((line = errorReader.readLine()) != null) {
 			if (step == 0) {
 				if (line.startsWith("WARNING: ")) {
-					if (listener != null)
-						listener.message(line);
+					if (listener != null) listener.message(line);
 				} else {
-					if (!line.startsWith("Output #0")) {
-						throw new EncoderException(line);
-					}
+					if (!line.startsWith("Output #0"))
+						if (listener != null) listener.message(line);
 					step++;
 				}
-			} else if ((step == 1) &&
-					(!line.startsWith("  "))) {
+			} else if ((step == 1) && (!line.startsWith("  "))) {
 				step++;
-			}
-
-			if (step == 2) {
-				if (!line.startsWith("Stream mapping:")) {
-					throw new EncoderException(line);
-				}
+			} else if (step == 2) {
+				if (!line.startsWith("Stream mapping:"))
+					if (listener != null) listener.message(line);
 				step++;
-			}
-			else if ((step == 3) &&
-					(!line.startsWith("  "))) {
+			} else if ((step == 3) && (!line.startsWith("  "))) {
 				step++;
-			}
-
-			if (step == 4) {
+			} else if (step == 4) {
 				line = line.trim();
 				if (line.length() > 0) {
 					Hashtable table = parseProgressInfoLine(line);
-					if (table == null) {
-						if (listener != null) {
-							listener.message(line);
-						}
-						lastWarning = line;
-					} else {
+					if (table != null) {
 						if (listener != null) {
 							String time = (String)table.get("time");
-							if (time != null) {
-								int dot = time.indexOf(46);
-								if ((dot > 0) && (dot == time.length() - 2) && (duration > 0L))
-								{
-									String p1 = time.substring(0, dot);
-									String p2 = time.substring(dot + 1);
-									try {
-										long i1 = Long.parseLong(p1);
-										long i2 = Long.parseLong(p2);
-										progress = i1 * 1000L + i2 * 100L;
-
-										int perm = (int)Math.round(progress * 1000L / duration);
-
-										if (perm > 1000) {
-											perm = 1000;
-										}
-										listener.progress(perm);
-									}
-									catch (NumberFormatException e) {
-									}
+							if (time != null && (duration > 0L)) {
+								try {
+									Date data = simpleDateFormat.parse(time);
+									calendar.setTime(data);
+									int hour = calendar.get(Calendar.HOUR_OF_DAY);
+									int minute = calendar.get(Calendar.MINUTE);
+									int second = calendar.get(Calendar.SECOND);
+									long i1 = (second + minute * 60 + hour * 60 * 60);
+									progress = i1 * 1000L;
+									int perm = Math.round(progress * 1000L / duration);
+									if (perm > 1000) perm = 1000;
+									listener.progress(perm);
+								} catch (Exception e) {
+									e.printStackTrace();
 								}
+
 							}
 						}
-						lastWarning = null;
 					}
 				}
 			}
 		}
-		if ((lastWarning != null) &&
-				(!SUCCESS_PATTERN.matcher(lastWarning).matches()))
-			throw new EncoderException(lastWarning);
 	}
-
 }

--- a/src/main/java/it/sauronsoftware/jave/Encoder.java
+++ b/src/main/java/it/sauronsoftware/jave/Encoder.java
@@ -845,27 +845,6 @@ public class Encoder {
 		}
 	}
 
-	/**
-	 *
-	 * @param cmdList
-	 * @throws EncoderException
-	 */
-	public void encode(File source, List<String> cmdList, EncoderProgressListener listener) throws EncoderException {
-		FFMPEGExecutor ffmpeg = locator.createExecutor();
-		ffmpeg.addArgument("-i");
-		ffmpeg.addArgument(source.getAbsolutePath());
-		for (String s : cmdList) {
-			ffmpeg.addArgument(s);
-		}
-		try {
-			ffmpeg.execute();
-		} catch (IOException e) {
-			throw new EncoderException(e);
-		} finally {
-			ffmpeg.destroy();
-		}
-	}
-
 	protected void processErrorOutput(EncodingAttributes attributes, BufferedReader errorReader, File source, EncoderProgressListener listener) throws EncoderException, IOException {
 		String lastWarning = null;
 		long progress = 0L;

--- a/src/main/java/it/sauronsoftware/jave/FFMPEGExecutor.java
+++ b/src/main/java/it/sauronsoftware/jave/FFMPEGExecutor.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
  *
  * @author Carlo Pelliccia
  */
-class FFMPEGExecutor {
+public class FFMPEGExecutor {
     private static final Logger log = LoggerFactory.getLogger(FFMPEGExecutor.class);
     /**
      * The path of the ffmpeg executable.

--- a/src/main/java/it/sauronsoftware/jave/FFMPEGLocator.java
+++ b/src/main/java/it/sauronsoftware/jave/FFMPEGLocator.java
@@ -33,7 +33,7 @@ public abstract class FFMPEGLocator {
 	 * 
 	 * @return The path of the ffmpeg executable.
 	 */
-	protected abstract String getFFMPEGExecutablePath();
+	public abstract String getFFMPEGExecutablePath();
 
 	/**
 	 * It returns a brand new {@link FFMPEGExecutor}, ready to be used in a
@@ -42,7 +42,7 @@ public abstract class FFMPEGLocator {
 	 * @return A newly instanced {@link FFMPEGExecutor}, using this locator to
 	 *         call the ffmpeg executable.
 	 */
-	FFMPEGExecutor createExecutor() {
+	public FFMPEGExecutor createExecutor() {
 		return new FFMPEGExecutor(getFFMPEGExecutablePath());
 	}
 

--- a/src/main/java/it/sauronsoftware/jave/FormatEnum.java
+++ b/src/main/java/it/sauronsoftware/jave/FormatEnum.java
@@ -1,0 +1,52 @@
+package it.sauronsoftware.jave;
+
+import java.io.File;
+
+/**
+ * @description:
+ * @author: zhuyawei
+ * @date: 2020-01-08 13:39
+ */
+public enum FormatEnum {
+    def(){
+        @Override
+        public void handle(FFMPEGExecutor ffmpeg, File target) {
+            ffmpeg.addArgument("-y");
+            ffmpeg.addArgument(target.getAbsolutePath());
+        }
+    },
+    ssegment(){
+        @Override
+        public void handle(FFMPEGExecutor ffmpeg, File target) {
+            ffmpeg.addArgument("-map");
+            ffmpeg.addArgument("0");
+            ffmpeg.addArgument("-segment_format");
+            ffmpeg.addArgument("mpegts");
+            ffmpeg.addArgument("-segment_list");
+            if(!target.getParentFile().exists())target.getParentFile().mkdirs();
+            ffmpeg.addArgument(target.getAbsolutePath());//拼接存放目录
+            ffmpeg.addArgument("-segment_time");
+            ffmpeg.addArgument("10");
+            ffmpeg.addArgument(target.getParent() + File.separator + "%03d.ts");//拼接存放目录
+        }
+    };
+
+    FormatEnum() {}
+
+    public abstract void handle(FFMPEGExecutor ffmpeg, File target);
+
+    public static FormatEnum get(String name){
+        if(name == null || name.isEmpty()) return def;
+        try{
+            return FormatEnum.valueOf(name);
+        }catch (IllegalArgumentException e){
+            return def;
+        }
+    }
+
+    public static void main(String[] args) {
+
+        System.out.println(FormatEnum.get("ssegment"));
+    }
+
+}

--- a/src/main/java/it/sauronsoftware/jave/VideoUtils.java
+++ b/src/main/java/it/sauronsoftware/jave/VideoUtils.java
@@ -1,8 +1,6 @@
 package it.sauronsoftware.jave;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 视频相关工具
@@ -33,14 +31,18 @@ public class VideoUtils {
         }
     }
 
-    public static void mp4ToM3u8(String source, String target, VideoSize videoSize) {
-        mp4ToM3u8(new File(source), new File(target), videoSize);
+    public static void mp4ToM3u8(String source, String target) {
+        mp4ToM3u8(source, target, null, null);
     }
 
-    /**
-     * mp4转m3u8
-     * @param source
-     */
+    public static void mp4ToM3u8(File source, File target) {
+        mp4ToM3u8(source, target, null, null);
+    }
+
+    public static void mp4ToM3u8(String source, String target, VideoSize videoSize) {
+        mp4ToM3u8(source, target, videoSize, null);
+    }
+
     public static void mp4ToM3u8(File source, File target, VideoSize videoSize) {
         mp4ToM3u8(source, target, videoSize, null);
     }
@@ -54,15 +56,12 @@ public class VideoUtils {
      * @param source
      */
     public static void mp4ToM3u8(File source, File target, VideoSize videoSize, EncoderProgressListener listener) {
-//        Encoder encoder = new IgnoreErrorEncoder();
         Encoder encoder = new Encoder();
         VideoAttributes video = new VideoAttributes();
         video.setCodec("libx264");
         video.setSize(videoSize);
-
         AudioAttributes audio = new AudioAttributes();
         audio.setCodec("mp3");
-
         EncodingAttributes attrs = new EncodingAttributes();
         attrs.setFormat(FormatEnum.ssegment.name());
         attrs.setVideoAttributes(video);

--- a/src/main/java/it/sauronsoftware/jave/VideoUtils.java
+++ b/src/main/java/it/sauronsoftware/jave/VideoUtils.java
@@ -1,6 +1,8 @@
 package it.sauronsoftware.jave;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 视频相关工具
@@ -12,15 +14,11 @@ public class VideoUtils {
 
     /**
      * 获取视频缩略图
-     *
      * @param source      视频来源
      * @param imageTarget 缩略图存放目标文件
      * @param offset      时间（秒）
      */
     public static void thumbnail(File source, File imageTarget, float offset) {
-        if (!source.exists()) {
-            throw new IllegalArgumentException("source file does not exists: " + source.getAbsoluteFile());
-        }
         Encoder encoder = new IgnoreErrorEncoder();
         VideoAttributes video = new VideoAttributes();
         EncodingAttributes attrs = new EncodingAttributes();
@@ -33,6 +31,37 @@ public class VideoUtils {
         } catch (Exception e) {
             throw new IllegalStateException("error: ", e);
         }
-
     }
+
+    public static void mp4ToM3u8(String source, String target, VideoSize videoSize) {
+        mp4ToM3u8(new File(source), new File(target), videoSize);
+    }
+
+    /**
+     * mp4转m3u8
+     * @param source
+     */
+    public static void mp4ToM3u8(File source, File target, VideoSize videoSize) {
+        Encoder encoder = new IgnoreErrorEncoder();
+        VideoAttributes video = new VideoAttributes();
+        video.setCodec("libx264");
+        video.setSize(videoSize);
+
+        AudioAttributes audio = new AudioAttributes();
+        audio.setCodec("mp3");
+
+        EncodingAttributes attrs = new EncodingAttributes();
+        attrs.setFormat(FormatEnum.ssegment.name());
+        attrs.setVideoAttributes(video);
+        attrs.setAudioAttributes(audio);
+        try {
+            encoder.encode(source, target, attrs);
+        } catch (Exception e) {
+            throw new IllegalStateException("error: ", e);
+        }
+    }
+
+
+
+
 }

--- a/src/main/java/it/sauronsoftware/jave/VideoUtils.java
+++ b/src/main/java/it/sauronsoftware/jave/VideoUtils.java
@@ -42,7 +42,20 @@ public class VideoUtils {
      * @param source
      */
     public static void mp4ToM3u8(File source, File target, VideoSize videoSize) {
-        Encoder encoder = new IgnoreErrorEncoder();
+        mp4ToM3u8(source, target, videoSize, null);
+    }
+
+    public static void mp4ToM3u8(String source, String target, VideoSize videoSize, EncoderProgressListener listener) {
+        mp4ToM3u8(new File(source), new File(target), videoSize, listener);
+    }
+
+    /**
+     * mp4转m3u8
+     * @param source
+     */
+    public static void mp4ToM3u8(File source, File target, VideoSize videoSize, EncoderProgressListener listener) {
+//        Encoder encoder = new IgnoreErrorEncoder();
+        Encoder encoder = new Encoder();
         VideoAttributes video = new VideoAttributes();
         video.setCodec("libx264");
         video.setSize(videoSize);
@@ -55,12 +68,11 @@ public class VideoUtils {
         attrs.setVideoAttributes(video);
         attrs.setAudioAttributes(audio);
         try {
-            encoder.encode(source, target, attrs);
+            encoder.encode(source, target, attrs, listener);
         } catch (Exception e) {
             throw new IllegalStateException("error: ", e);
         }
     }
-
 
 
 


### PR DESCRIPTION
开放FFMPEGExecutor类和FFMPEGLocator类的createExecutor方发
新增FormatEnum枚举类，定义各个格式类型转换需要设定的参数，在Encoder类的encode方法执行ffmpeg.execute()前，执行FormatEnum.get(formatAttribute).handle(ffmpeg, target)，添加对应的执行命令
VideoUtils 新增m3u8方法